### PR TITLE
sell action

### DIFF
--- a/application.py
+++ b/application.py
@@ -35,8 +35,14 @@ def index():
 
 @app.route('/actions/buy', methods=['POST'])
 @decorators.login_required
-def actions():
+def actionsBuy():
   return index_controller.buyAction()
+
+
+@app.route('/actions/sell', methods=['POST'])
+@decorators.login_required
+def actionsSell():
+  return index_controller.sellAction()
 
 
 @app.route('/sign-in', methods=['GET', 'POST'])

--- a/controllers/index_controller.py
+++ b/controllers/index_controller.py
@@ -15,17 +15,14 @@ def getIndexPage():
   return render_template('pages/index.html', actions=actions)
 
 
-def buyAction():
-  symbol = request.form['symbol']
-  shares = int(request.form['shares'])
-
+def getRealtimeAction(symbol, shares):
   quote = quotes_repository.getStockQuotes(symbol)[0]
   
   if quote is None:
     error = { 'code': 400, 'error': f'symbol {symbol} not exists' }
     return jsonify(error), 400
 
-  action = ActionCreateDTO(
+  return ActionCreateDTO(
     id=Cuid().generate(),
     symbol=quote['symbol'],
     name=quote['companyName'],
@@ -34,10 +31,16 @@ def buyAction():
     userId=session['id'],
   )
 
+def buyAction():
+  symbol = request.form['symbol']
+  shares = int(request.form['shares'])
+
+  action = getRealtimeAction(symbol, shares)
+
   newFunds = session['funds'] - action.fundsDiscount
 
   if newFunds <= 0:
-    error = { 'code': 400, 'error': 'missing funds'}
+    error = { 'code': 400, 'error': 'insufficient funds'}
     return jsonify(error), 400
   
   transactions_repository.buyAction(action)
@@ -47,4 +50,36 @@ def buyAction():
   return jsonify({ 'result': 'ok' }), 200
 
 
+def sellAction():
+  symbol = request.form['symbol']
+  shares = int(request.form['shares'])
+
+  # Verifica se o usuário possui ações daquele símbolo (totalShares >= request.form['shares'])
+  action = transactions_repository.getActionBySymbol(symbol, session['id'])
+
+  if action is None:
+    error = { 'code': 400, 'error': f'you don\'t have {symbol} shares' }
+    return jsonify(error), 400
+  
+  if action.shares < shares:
+    error = { 'code': 400, 'error': 'insufficient shares' }
+    return jsonify(error), 400
+  
+  # Obtém o valor das ações do símbolo em tempo real
+  action = getRealtimeAction(symbol, shares)
+
+  if action.price == 0:
+    error = {
+      'code': 400,
+      'error': 'Unable to get current share price. Try again later',
+    }
+
+    return jsonify(error), 400
+
+  # Cadastra a transação e atualiza o saldo do usuário
+  transactions_repository.sellAction(action)
+  
+  session['funds'] = session['funds'] + action.fundsDiscount
+
+  return jsonify({ 'result': 'ok' }), 200
 

--- a/controllers/index_controller.py
+++ b/controllers/index_controller.py
@@ -6,11 +6,12 @@ from entities.transaction import ActionCreateDTO
 def getIndexPage():
   actions = transactions_repository.getActiveActions(userId=session['id'])
 
-  symbols = map(lambda action: action.symbol, actions)
-  quotes = quotes_repository.getStockPrices(symbols)
+  if (len(actions) > 0):
+    symbols = map(lambda action: action.symbol, actions)
+    quotes = quotes_repository.getStockPrices(symbols)
 
-  for action in actions:
-    action.price = quotes[action.symbol]['price']
+    for action in actions:
+      action.price = quotes[action.symbol]['price']
 
   return render_template('pages/index.html', actions=actions)
 

--- a/controllers/index_controller.py
+++ b/controllers/index_controller.py
@@ -38,7 +38,7 @@ def buyAction():
 
   action = getRealtimeAction(symbol, shares)
 
-  newFunds = session['funds'] - action.fundsDiscount
+  newFunds = session['funds'] - action.totalSharePrice
 
   if newFunds <= 0:
     error = { 'code': 400, 'error': 'insufficient funds'}
@@ -80,7 +80,7 @@ def sellAction():
   # Cadastra a transação e atualiza o saldo do usuário
   transactions_repository.sellAction(action)
   
-  session['funds'] = session['funds'] + action.fundsDiscount
+  session['funds'] = session['funds'] + action.totalSharePrice
 
   return jsonify({ 'result': 'ok' }), 200
 

--- a/controllers/index_controller.py
+++ b/controllers/index_controller.py
@@ -40,7 +40,7 @@ def buyAction():
 
   newFunds = session['funds'] - action.totalSharePrice
 
-  if newFunds <= 0:
+  if newFunds < 0:
     error = { 'code': 400, 'error': 'insufficient funds'}
     return jsonify(error), 400
   

--- a/entities/transaction.py
+++ b/entities/transaction.py
@@ -20,7 +20,7 @@ class ActionCreateDTO:
     self.userId = userId
   
   @property
-  def fundsDiscount(self):
+  def totalSharePrice(self):
     return self.shares * self.price
 
 

--- a/repositories/transactions_repository.py
+++ b/repositories/transactions_repository.py
@@ -16,7 +16,7 @@ def buyAction(action: ActionCreateDTO):
       cursor.execute(
         'UPDATE users SET funds = funds - ? WHERE id = ?;',
         (
-          action.fundsDiscount,
+          action.totalSharePrice,
           action.userId,
         ),
       )
@@ -53,7 +53,7 @@ def sellAction(action: ActionCreateDTO):
       cursor.execute(
         'UPDATE users SET funds = funds + ? WHERE id = ?;',
         (
-          action.fundsDiscount,
+          action.totalSharePrice,
           action.userId,
         ),
       )

--- a/repositories/transactions_repository.py
+++ b/repositories/transactions_repository.py
@@ -38,7 +38,44 @@ def buyAction(action: ActionCreateDTO):
       cursor.execute('commit')
     except:
       cursor.execute('rollback')
-    
+
+
+def sellAction(action: ActionCreateDTO):
+  with dbconnection.connect() as con:
+    con.row_factory = sqlite3.Row
+
+    con.isolation_level = None
+    cursor = con.cursor()
+
+    cursor.execute('begin')
+
+    try:
+      cursor.execute(
+        'UPDATE users SET funds = funds + ? WHERE id = ?;',
+        (
+          action.fundsDiscount,
+          action.userId,
+        ),
+      )
+
+      cursor.execute(
+        '''
+        INSERT INTO transactions (id, symbol, name, shares, price, user_id, operation)
+        VALUES (?, ?, ?, ?, ?, ?, 'sell');
+        ''',
+        (
+          action.id,
+          action.symbol,
+          action.name,
+          action.shares,
+          action.price,
+          action.userId,
+        ),
+      )
+      cursor.execute('commit')
+    except:
+      cursor.execute('rollback')
+
 
 def getActiveActions(userId: str) -> list[Action]:
   with dbconnection.connect() as con:
@@ -76,6 +113,42 @@ def getActiveActions(userId: str) -> list[Action]:
       items.append(action)
 
     return items
+
+
+def getActionBySymbol(symbol, userId: str) -> Action:
+  with dbconnection.connect() as con:
+    con.row_factory = sqlite3.Row
+
+    result = con.execute(
+      '''
+      SELECT
+        symbol,
+        name,
+        SUM(
+          CASE WHEN (operation = 'buy')
+          THEN shares
+          ELSE -shares
+          END
+        ) as total_shares
+      FROM transactions
+      WHERE symbol = ? AND user_id = ?
+      GROUP BY symbol
+      HAVING total_shares > 0;
+      ''',
+      (symbol, userId,),
+    )
+
+    row = result.fetchone()
+
+    if row is None:
+      return None
+
+    return Action(
+      symbol=row['symbol'],
+      name=row['name'],
+      shares=row['total_shares'],
+      price=0.0,
+    )
 
 
 def getAllTransactions(userId: str) -> list[Transaction]:

--- a/static/scripts/custom/action-modal.js
+++ b/static/scripts/custom/action-modal.js
@@ -1,0 +1,45 @@
+const actionFormEl = document.getElementById('action-modal-form');
+const actionModalTitle = document.querySelector('#action-modal .uk-modal-title');
+const submitButtonEl = document.querySelector('#action-modal-form button[type=submit]');
+const actionModalAlertEl = document.getElementById('action-modal-alert');
+
+const forms = {
+  buy: {
+    title: 'Buy action',
+    buttonText: 'Buy',
+    formAction: '/actions/buy'
+  },
+  sell: {
+    title: 'Sell action',
+    buttonText: 'Sell',
+    formAction: '/actions/sell'
+  },
+}
+
+const updateActionModalForm = (formName, symbol = '', shares = '') => {
+  const { title, buttonText, formAction } = forms[formName] || {};
+
+  actionModalTitle.textContent = title;
+  submitButtonEl.querySelector('.submit-content').textContent = buttonText;
+  actionFormEl.setAttribute('action', formAction);
+  actionFormEl.symbol.value = symbol;
+  actionFormEl.shares.value = '';
+  actionFormEl.shares.max = shares;
+};
+
+actionFormEl.addEventListener('submit', async (e) => {
+  e.preventDefault();
+
+  try {
+    setLoading(true, submitButtonEl);
+    setError(null, actionModalAlertEl);
+
+    await sendFormData(e.target);
+    
+    location.reload();
+  } catch (e) {
+    setError(error, actionModalAlertEl);
+  } finally {
+    setLoading(false, submitButtonEl);
+  }
+});

--- a/static/scripts/custom/helpers.js
+++ b/static/scripts/custom/helpers.js
@@ -1,0 +1,44 @@
+const setLoading = (isLoading, buttonElement) => {
+  const spinnerEl = buttonElement.querySelector('[uk-spinner]');
+
+  if (isLoading) {
+    buttonElement.setAttribute('disabled', 'disabled');
+
+    if (spinnerEl) {
+      spinnerEl.classList.remove('uk-hidden');
+    }
+  } else {
+    buttonElement.removeAttribute('disabled');
+
+    if (spinnerEl) {
+      spinnerEl.classList.add('uk-hidden');
+    }
+  }
+}
+
+const setError = (message, alertElement) => {
+  alertElement.textContent = message;
+  
+  if (message) {
+    alertElement.classList.remove('uk-hidden');
+  } else {
+    alertElement.classList.add('uk-hidden');
+  }
+}
+
+const sendFormData = async (formElement) => {
+  const result = await fetch(formElement.action, {
+    method: 'post',
+    body: new FormData(formElement),
+  });
+
+  if (result.ok) {
+    return true;
+  }
+
+  const {
+    error = 'unexpected error',
+  } = await result.json().catch(() => ({}));
+
+  throw error;
+}

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -4,8 +4,9 @@
 
 <button
   class="uk-button uk-button-primary"
-  uk-toggle="target: #buy-action-modal"
+  uk-toggle="target: #action-modal"
   type="button"
+  onclick="updateActionModalForm('buy')"
 >
   Buy Action
 </button>
@@ -60,7 +61,14 @@
         </td>
         
         <td>
-          <button class="uk-button uk-button-primary-outlined">
+          <button
+            class="uk-button uk-button-primary-outlined"
+            uk-toggle="target: #action-modal;"
+            data-action="sell"
+            data-symbol=""
+            data-shares="{{ action.shares }}"
+            onclick="updateActionModalForm('sell', '{{ action.symbol }}', '{{ action.shares }}')"
+          >
             Sell
           </button>
         </td>
@@ -70,15 +78,16 @@
   </table>
 </div>
 
-<div id="buy-action-modal" uk-modal>
+<div id="action-modal" uk-modal="esc-close: false; bg-close: false;">
     <div class="uk-modal-dialog uk-margin-auto-vertical uk-modal-body form-small">
       <button class="uk-modal-close-default" type="button" uk-close></button>
 
-      <h2 class="uk-modal-title">Buy action</h2>
+      <!-- i.e. Sell Action -->
+      <h2 class="uk-modal-title"></h2>
 
-      <div id="buy-action-alert" class="uk-alert-danger uk-hidden" uk-alert></div>
+      <div id="action-modal-alert" class="uk-alert-danger uk-hidden" uk-alert></div>
 
-      <form id="buy-action-form">
+      <form id="action-modal-form" method="POST">
         <label class="uk-display-block">
           <span class="uk-form-label">Symbol</span>
           <input
@@ -102,55 +111,17 @@
         </label>
 
         <button
-          id="buy-button"
           type="submit"
           class="uk-button uk-button-primary uk-width-1-1"
         >
           <div class="uk-margin-right-small uk-hidden" uk-spinner="ratio: 0.75;"></div>
-          <span>Buy</span>
+          <span class="submit-content"></span>
         </button>
       </form>
     </div>
 </div>
 
-<script>
-  const buyActionFormEl = document.getElementById('buy-action-form');
-  const buyButtonEl = document.getElementById('buy-button');
-  const buySpinnerEl = document.querySelector('#buy-action-form [uk-spinner]');
-  const buyActionAlertEl = document.getElementById('buy-action-alert');
-
-  buyActionFormEl.addEventListener('submit', async (e) => {
-    e.preventDefault();
-
-    const {
-      symbol: { value: symbol },
-      shares : { value: shares }
-    } = buyActionFormEl;
-
-    buyButtonEl.setAttribute('disabled', 'disabled')
-    buySpinnerEl.classList.remove('uk-hidden');
-    
-    const result = await fetch('/actions/buy', {
-      method: 'post',
-      body: new FormData(buyActionFormEl)
-    });
-    
-    
-    if (result.ok) {
-      location.reload();
-      return;
-    }
-    
-    const {
-      error = 'unexpected error',
-    } = await result.json().catch(() => ({}));
-
-    buyButtonEl.removeAttribute('disabled');
-    buySpinnerEl.classList.add('uk-hidden');
-
-    buyActionAlertEl.textContent = error;
-    buyActionAlertEl.classList.remove('uk-hidden');
-  });
-</script>
+<script src="/static/scripts/custom/helpers.js"></script>
+<script src="/static/scripts/custom/action-modal.js"></script>
 
 {% endblock %}

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -64,9 +64,6 @@
           <button
             class="uk-button uk-button-primary-outlined"
             uk-toggle="target: #action-modal;"
-            data-action="sell"
-            data-symbol=""
-            data-shares="{{ action.shares }}"
             onclick="updateActionModalForm('sell', '{{ action.symbol }}', '{{ action.shares }}')"
           >
             Sell


### PR DESCRIPTION
Implementa a lógica de venda de ações, reutilizando o modal de compra das ações, apenas substituindo o título, texto do botão de submit e action para onde o formulário será enviado.
Também corrige um bug em contas sem ações onde uma consulta na API do IEX era realizada sem a lista de symbols, retornando um erro.